### PR TITLE
Changed `DecimalField` behaviour to allow compatible types

### DIFF
--- a/ognom/fields.py
+++ b/ognom/fields.py
@@ -3,7 +3,7 @@ import re
 import sys
 import uuid
 import datetime
-from decimal import Decimal
+import decimal
 
 import six
 from bson import ObjectId
@@ -123,7 +123,7 @@ class IntField(GenericField):
 class FloatField(GenericField):
     def validate(self, value):
         super(FloatField, self).validate(value)
-        if not isinstance(value, (float, Decimal, six.integer_types)):
+        if not isinstance(value, (float, decimal.Decimal, six.integer_types)):
             raise ValidationError(
                 '[{}] Can\'t convert {} of type {} to float'.format(
                     self.name, value, type(value)), self.name)
@@ -135,7 +135,9 @@ class FloatField(GenericField):
 class DecimalField(GenericField):
     def validate(self, value):
         super(DecimalField, self).validate(value)
-        if not isinstance(value, Decimal):
+        try:
+            decimal.Decimal(value)
+        except decimal.InvalidOperation:
             raise ValidationError(
                 '[{}] Can\'t convert {} of type {} to Decimal'.format(
                     self.name, value, type(value)), self.name)
@@ -144,7 +146,7 @@ class DecimalField(GenericField):
         return six.text_type(value)
 
     def from_mongo(self, value):
-        return Decimal(value)
+        return decimal.Decimal(value)
 
 
 class UUIDField(GenericField):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -87,6 +87,20 @@ class TestDecimalField(unittest.TestCase):
         value = self.field.from_mongo('3.1415926535897932384')
         assert value == Decimal('3.1415926535897932384')
 
-    def test_should_accept_only_decimal(self):
-        with pytest.raises(ValidationError):
-            self.field.validate(10)
+    def test_validate_non_compatible_decimals(self):
+        wrong_values = [
+            'string',
+            '1/2',
+        ]
+        for value in wrong_values:
+            self.assertRaises(ValidationError, self.field.validate, value)
+
+    def test_validate_regular_url(self):
+        valid_urls = [
+            1,
+            50.51,
+            Decimal('1'),
+            Decimal('50.51'),
+        ]
+        for url in valid_urls:
+            self.assertIsNone(self.field.validate(url))


### PR DESCRIPTION
`DecimalField` should accept numerical values and strigified numerical values (`'10'`, `'2.79'`, etc) like `Decimal` type does. The same idea as `FloatField` does to compatible types.
