### PR TITLE
Added `PyPy` interpreter as tests target since `ognom` is compatible with it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34
+    - TOXENV=pypy
     - TOXENV=pep8
 
 branches:

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     license='MIT',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, pep8
+envlist = py27, py33, py34, pypy, pep8
 
 [testenv]
 commands = py.test tests/


### PR DESCRIPTION
> Supports python2.7+, python3.3+, PyPy.

Note: git may find conflicts with #3 (both PR edit `.travis.yml` file).
